### PR TITLE
I2pservice

### DIFF
--- a/AddressBook.h
+++ b/AddressBook.h
@@ -23,6 +23,8 @@ namespace client
 	const int CONTINIOUS_SUBSCRIPTION_UPDATE_TIMEOUT = 240; // in minutes			
 	const int CONTINIOUS_SUBSCRIPTION_RETRY_TIMEOUT = 5; // in minutes	
 	const int SUBSCRIPTION_REQUEST_TIMEOUT = 60; //in second
+	
+	inline std::string GetB32Address(const i2p::data::IdentHash& ident) { return ident.ToBase32().append(".b32.i2p"); }
 
 	class AddressBookStorage // interface for storage
 	{
@@ -55,7 +57,7 @@ namespace client
 			void LoadHostsFromStream (std::istream& f);
 			void DownloadComplete (bool success);
 			//This method returns the ".b32.i2p" address
-			std::string ToAddress(const i2p::data::IdentHash& ident) { return ident.ToBase32().append(".b32.i2p"); }
+			std::string ToAddress(const i2p::data::IdentHash& ident) { return GetB32Address(ident); }
 			std::string ToAddress(const i2p::data::IdentityEx& ident) { return ToAddress(ident.GetIdentHash ()); }
 		private:
 

--- a/Destination.cpp
+++ b/Destination.cpp
@@ -6,7 +6,7 @@
 #include "ElGamal.h"
 #include "Timestamp.h"
 #include "NetDb.h"
-#include "ClientContext.h"
+#include "AddressBook.h"
 #include "Destination.h"
 
 namespace i2p
@@ -47,7 +47,7 @@ namespace client
 		}	
 		m_Pool = i2p::tunnel::tunnels.CreateTunnelPool (this, inboundTunnelLen, outboundTunnelLen);  
 		if (m_IsPublic)
-			LogPrint (eLogInfo, "Local address ", i2p::client::context.GetAddressBook ().ToAddress(GetIdentHash()), " created");
+			LogPrint (eLogInfo, "Local address ", i2p::client::GetB32Address(GetIdentHash()), " created");
 		m_StreamingDestination = new i2p::stream::StreamingDestination (*this); // TODO:
 	}
 

--- a/HTTPProxy.cpp
+++ b/HTTPProxy.cpp
@@ -62,7 +62,7 @@ namespace proxy
 		LogPrint(eLogDebug,"--- HTTP Proxy async sock read");
 		if(m_sock) {
 			m_sock->async_receive(boost::asio::buffer(m_http_buff, http_buffer_size),
-						std::bind(&HTTPProxyHandler::HandleSockRecv, this,
+						std::bind(&HTTPProxyHandler::HandleSockRecv, shared_from_this(),
 								std::placeholders::_1, std::placeholders::_2));
 		} else {
 			LogPrint(eLogError,"--- HTTP Proxy no socket for read");
@@ -86,7 +86,7 @@ namespace proxy
 	{
 		std::string response = "HTTP/1.0 500 Internal Server Error\r\nContent-type: text/html\r\nContent-length: 0\r\n";
 		boost::asio::async_write(*m_sock, boost::asio::buffer(response,response.size()),
-					 std::bind(&HTTPProxyHandler::SentHTTPFailed, this, std::placeholders::_1));
+					 std::bind(&HTTPProxyHandler::SentHTTPFailed, shared_from_this(), std::placeholders::_1));
 	}
 
 	void HTTPProxyHandler::EnterState(HTTPProxyHandler::state nstate) {
@@ -197,7 +197,7 @@ namespace proxy
 			if (m_state == DONE) {
 				LogPrint(eLogInfo,"--- HTTP Proxy requested: ", m_url);
 				GetOwner()->CreateStream (std::bind (&HTTPProxyHandler::HandleStreamRequestComplete,
-						this, std::placeholders::_1), m_address, m_port);
+						shared_from_this(), std::placeholders::_1), m_address, m_port);
 			} else {
 				AsyncSockRead();
 			}

--- a/I2PService.h
+++ b/I2PService.h
@@ -21,24 +21,27 @@ namespace client
 			I2PService (i2p::data::SigningKeyType kt);
 			virtual ~I2PService () { ClearHandlers (); }
 
-			inline void AddHandler (std::shared_ptr<I2PServiceHandler> conn) {
+			inline void AddHandler (std::shared_ptr<I2PServiceHandler> conn)
+			{
 				std::unique_lock<std::mutex> l(m_HandlersMutex);
 				m_Handlers.insert(conn);
 			}
-			inline void RemoveHandler (std::shared_ptr<I2PServiceHandler> conn) {
+			inline void RemoveHandler (std::shared_ptr<I2PServiceHandler> conn)
+			{
 				std::unique_lock<std::mutex> l(m_HandlersMutex);
 				m_Handlers.erase(conn);
 			}
-			inline void ClearHandlers () {
+			inline void ClearHandlers ()
+			{
 				std::unique_lock<std::mutex> l(m_HandlersMutex);
 				m_Handlers.clear();
 			}
 
-			inline ClientDestination * GetLocalDestination () { return m_LocalDestination; };
-			inline void SetLocalDestination (ClientDestination * dest) { m_LocalDestination = dest; };
+			inline ClientDestination * GetLocalDestination () { return m_LocalDestination; }
+			inline void SetLocalDestination (ClientDestination * dest) { m_LocalDestination = dest; }
 			void CreateStream (StreamRequestComplete streamRequestComplete, const std::string& dest, int port = 0);
 
-			inline boost::asio::io_service& GetService () { return m_LocalDestination->GetService (); };
+			inline boost::asio::io_service& GetService () { return m_LocalDestination->GetService (); }
 
 			virtual void Start () = 0;
 			virtual void Stop () = 0;


### PR DESCRIPTION
Remove client context dependencies, use shared from this on SOCKS and http proxyes to avoid early release of object on stop.